### PR TITLE
Fetch only two builds by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 [![crates.io](https://img.shields.io/crates/d/fetchchromium)](https://crates.io/crates/fetchchromium)
 [![docs.rs](https://docs.rs/fetchchromium/badge.svg)](https://docs.rs/fetchchromium)
 
-A tool to fetch Chromium builds.
+A tool to fetch Chromium builds. This is a thin wrapper above the [ripunzip library](https://github.com/google/ripunzip)
+which aims to unzip files in parallel as efficiently as possible.
+
+#### Installation and use
+
+`cargo install fetchchromium` then `fetchchromium -h`. Alternatively,
+a `.deb` file is available under the "releases" section on github.
+
+#### Development
+
+Release procedure:
+1. Revise the version number
+2. `cargo publish`
+3. Retrieve the latest `.deb` file from the latest CI job
+4. Declare a new release and tag on github
+5. As you make that release, include the `.deb` file as an artifact.
 
 #### License and usage notes
 

--- a/src/builds.rs
+++ b/src/builds.rs
@@ -48,7 +48,6 @@ pub(crate) fn get_builds(
 ) -> Result<IndexSet<u64>> {
     let prefix = format_prefix(specification, version_prefix);
     let uri = format!("{BUCKET}?prefix={prefix}");
-    eprintln!("URI is {}", uri);
     let response = reqwest::blocking::get(uri)?;
     let bucket_result: ListBucketResult = serde_xml_rs::from_reader(response)?;
     let prefix_to_remove = format_prefix(specification, "").len();


### PR DESCRIPTION
To avoid unnecessarily hammering disk-write-bandwidth-limited VMs.