### PR TITLE
Build .deb on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
   deb:
     name: BuildDeb
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
     steps:


### PR DESCRIPTION
Since this will cause `cargo deb` to select better libssl versions successfully (libssl3 rather than libssl1). This happens automatically because cargo deb usess dpkg-shlibdeps.