### PR TITLE
Update setup-blank-vm.sh to enable unprivileged user namespaces

### DIFF
--- a/setup-blank-vm.sh
+++ b/setup-blank-vm.sh
@@ -21,6 +21,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt --fix-broken --assume-yes install
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes xfce4 llvm desktop-base dbus-x11 xscreensaver unzip unrar-free
 sudo bash -c 'echo "exec /etc/X11/Xsession /usr/bin/xfce4-session" > /etc/chrome-remote-desktop-session'
 
+echo "Enabling unprivileged user namespaces so Chrome can sandbox itself. Note that this slightly weakens the security of this VM's kernel against local attackers."
+echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+echo kernel.apparmor_restrict_unprivileged_userns=0 | sudo tee /etc/sysctl.d/60-apparmor-namespace.conf
+
 echo "Restarting the VM - please SSH in again, then run fetchchromium with whatever options you like (possibly none)"
 echo "and run the command given at https://remotedesktop.google.com/headless to set up CRD"
 sudo shutdown -r now


### PR DESCRIPTION
Ubuntu made entering a new user namespace back into a privileged operation. But Chromium's main sandbox is implemented using user namespaces, so it needs to be able to use them from an unprivileged process. This commit re-enables unprivileged user namespaces on Ubuntu.