### PR TITLE
Add snapshot_blob to default file patterns

### DIFF
--- a/src/chromium_filename_filter.rs
+++ b/src/chromium_filename_filter.rs
@@ -9,7 +9,7 @@
 use glob_match::glob_match;
 use ripunzip::FilenameFilter;
 
-static PATTERNS: [&str; 11] = [
+static PATTERNS: [&str; 12] = [
     "**/*.so",
     "**/chrome",
     "**/en-US.pak",
@@ -21,6 +21,7 @@ static PATTERNS: [&str; 11] = [
     "**/nacl_helper",
     "**/Chromium.app/**",
     "**/d8",
+    "**/snapshot_blob.bin",
 ];
 
 /// Knows what files are typically necessary for running Chromium.


### PR DESCRIPTION
In order to run the d8 binaries from the builders we also need the snapshot_blob.bin file.