### PR TITLE
Install `cargo-outdated` with `cargo-binstall`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       RUSTFLAGS: --cfg deny_warnings -Dwarnings
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
@@ -63,7 +63,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: hecrj/setup-rust-action@v1
       - run: cargo install cargo-deb # sadly not supported by dtolnay/install
       - name: BuildDeb
@@ -81,7 +81,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
@@ -95,10 +95,15 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/install@master
-        with:
-          crate: cargo-outdated
+      - uses: actions/checkout@v4
+      # Use `binstall` instead of `dtolnay/install` since:
+      #   (a) `cargo-outdated` is sensitive to the version of Cargo it's
+      #       built *with*, in that it might not be able to deal with
+      #       `Cargo.toml` files with newer features.
+      #   (b) empirically, `dtolnay/install` doesn't rebuild packages with
+      #       new versions of Cargo as promptly.
+      - uses: cargo-bins/cargo-binstall@v1.14.1
+      - run: cargo binstall cargo-outdated
       - run: cargo outdated -R -w
 
   # Check rustfmt is good
@@ -106,7 +111,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: hecrj/setup-rust-action@v1
         with:
           components: rustfmt


### PR DESCRIPTION
This should get us a version that is built with/against more recent versions of Cargo, which will in turn fix the error we're seeing in CI:

```
error: failed to parse manifest at `/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.8.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0).
  Consider trying a more recent nightly release.
```

We could also use `cargo install` but it is *very* slow (4m).

This change also updates all uses of `checkout@v2` to `checkout@v4`. Unfortunately, this is **not** just an unrelated cleanup: `checkout@v4` [stores an access token in the local Git repo config](https://github.com/actions/checkout/blob/09d2acae674a48949e3602304ab46fd20ae0c42f/README.md#checkout-v4), which in turn [gets picked up by `cargo-binstall`](https://github.com/cargo-bins/cargo-binstall/blob/8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8/crates/bin/src/args.rs#L384-L386) so it can access the Github REST API. Without the update, `cargo binstall` fails and falls back to compiling from source.